### PR TITLE
Drop Support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
-
-matrix:
-  include:
-    - python: 2.7
-    - python: 3.5
+python:
+  - 3.5
 
 install:
     - "pip install -r requirements.txt"


### PR DESCRIPTION
Let's use Python 3.5 only, so we don't have to worry about compatibility. 